### PR TITLE
fn+tilde sends Markdown codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Compile firmwares defined in `qmk.json`
 qmk userspace-compile
 ```
 
+Compile specific firmware
+
+```
+qmk compile -kb evyd13/plain60 -km saesh
+```
+
 Flash specific firmware
 
 ```

--- a/keyboards/evyd13/plain60/keymaps/saesh/keymap.c
+++ b/keyboards/evyd13/plain60/keymaps/saesh/keymap.c
@@ -4,6 +4,7 @@
 #define KC_SEC1 KC_SECRET_1
 #define KC_SEC2 KC_SECRET_2
 #define KC_SEC3 KC_SECRET_3
+#define KC_CDBLK SS_MARKDOWNCODEBLOCK
 
 enum _layer {
   _BASE,
@@ -21,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
            KC_LGUI, KC_LALT,                    KC_SPC,                                              KC_ALGR, _______),
 
 [_FN] = LAYOUT_60_hhkb(
-  _______,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12,  KC_INS, KC_DEL, \
+  _______,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,  KC_F12,  KC_INS, KC_CDBLK, \
   KC_CAPS, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,   KC_UP, _______,  KC_DEL, \
   _______, KC_VOLU, KC_VOLD, KC_MUTE, _______, _______, _______, _______, KC_HOME, KC_PGUP, KC_LEFT,KC_RIGHT,          _______, \
   _______,          _______, _______, _______, _______, _______, _______, _______,  KC_END, KC_PGDN, KC_DOWN, _______, _______, \

--- a/users/saesh/saesh.c
+++ b/users/saesh/saesh.c
@@ -6,5 +6,13 @@ bool secrets_process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch(keycode) {
+        case SS_MARKDOWNCODEBLOCK:
+            if (record->event.pressed) {
+                SEND_STRING("```\n\n```" SS_TAP(X_UP));
+            }
+            return false;
+    }
+
     return secrets_process_record_user(keycode, record);
 }

--- a/users/saesh/saesh.h
+++ b/users/saesh/saesh.h
@@ -7,6 +7,7 @@ enum user_custom_keys {
   KC_SECRET_2,
   KC_SECRET_3,
   KC_SECRET_4,
-  KC_SECRET_5
+  KC_SECRET_5,
+  SS_MARKDOWNCODEBLOCK // send string Markdown code block
 };
 


### PR DESCRIPTION
## Changes

- <kbd>fn</kbd> + <kbd>~</kbd> sends a Markdown codeblock